### PR TITLE
Facilitate use of secured Linux environments for application providers

### DIFF
--- a/documents/wip/securityFeatureDocumentation.txt
+++ b/documents/wip/securityFeatureDocumentation.txt
@@ -1,0 +1,59 @@
+LSB Specification Proposal
+
+State: Problem Statement
+------
+
+
+Problem Statement:
+------------------
+
+It can be difficult for application providers to install their products on Linux
+systems that have security features turned on compared to those with the
+features turned off. Documentation is needed to guide application providers
+for how to build their applications and installers for systems with SELinux and
+AppArmor in use as well as for non-secured systems.
+
+Many customers today want to use their preferred applications in a secure environment.
+A number of commercial applications are programmed to use more system facilities
+than are allowed to them in the secured environment. To complete the installation and
+run successfully, they advise the customer to turn off the security feature. The
+customer is then forced to make a decision between a more secure environment and
+using the application. Clearer advice on how to set up applications in secured
+environments would assist application providers in working within the environment.
+
+Ubuntu and openSUSE ship with AppArmor turned on by default.
+Fedora ships with SELinux turned on by default.
+
+
+(Proposed) Solution:
+--------------------
+
+Create guideline documentation for applications for installing and running within
+typical SELinux and AppArmor environments compared to environments not using them.
+
+
+Solution Discussion Links:
+--------------------------
+
+Provide links to at least 3 distribution mailing lists where this topic has
+been discussed.
+
+
+Solution Rationale:
+-------------------
+
+Provide a brief description how the documented solution was derived.
+
+
+Distributions Support:
+----------------------
+
+A list of distributions that have pledged to adhere to this specification and
+integrate the test into their QA suite.
+
+
+Verification Test:
+------------------
+
+Documentation, testing not required
+


### PR DESCRIPTION
- Transformed the proposal from issue #8 [1] to a proposal file
- Moved the Solution Rationale and Distributions Support sections to the Problem Statement, as these 'stages' are not yet reached (e.g. Ubuntu and openSUSE do not yet pledge to adhere to this specification, as there is no specification formed, yet)
- Added a State header with state "Problem Statement"
- Corrected the spelling of proper nouns (apparmor -> AppArmor, OpenSUSE -> openSUSE)

[1] https://github.com/LinuxStandardBase/lsb/issues/8
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/LinuxStandardBase/lsb/pull/15%23issuecomment-42491417%22%2C%20%22https%3A//github.com/LinuxStandardBase/lsb/pull/15%23issuecomment-42491564%22%2C%20%22https%3A//github.com/LinuxStandardBase/lsb/pull/15%23issuecomment-42859317%22%2C%20%22https%3A//github.com/LinuxStandardBase/lsb/pull/15%23issuecomment-42860289%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/LinuxStandardBase/lsb/pull/15%23issuecomment-42491417%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20is%20not%20a%20comment%20on%20the%20pull%20request%2C%20but%20a%20rant%20about%20something%20else%3A%20these%20things%20arrive%20by%20email%20and%20end%20up%20looking%20like%20crap%20because%20something%20is%20transforming%20characters.%20%20This%20issue%20looked%20like%20this%20when%20it%20landed%20in%20my%20mailbox%3A%5Cn-%20Transformed%20the%20proposal%20from%20issue%20%238%20%5B1%5D%20to%20a%20proposal%20file%5Cn-%20Moved%20the%20Solution%20Rationale%20and%20Distributions%20Support%20sections%20to%20the%20Problem%20Statement%2C%20as%20these%20%26%2339%3Bstages%26%2339%3B%20are%20not%20yet%20reached%20%28e.g.%20Ubuntu%20and%20openSUSE%20do%20not%20yet%20pledge%20to%20adhere%20to%20this%20specification%2C%20as%20there%20is%20no%20specification%20formed%2C%20yet%29%5Cn-%20Added%20a%20State%20header%20with%20state%20%26quot%3BProblem%20Statement%26quot%3B%5Cn-%20Corrected%20the%20spelling%20of%20proper%20nouns%20%28apparmor%20-%26gt%3B%20AppArmor%2C%20OpenSUSE%20-%26gt%3B%20openSUSE%29%5Cn%5Cn%26%2338%3B%20%3F%3F%20%40quot%3B%20%3F%3F%20%20%40gt%3B%20%3F%3F%5Cn%5CnIs%20there%20ANY%20way%20to%20fix%20it%20so%20the%20notification%20emails%20don%27t%20end%20up%20cluttered%20with%20this%20garbage%3F%20None%20of%20the%20characters%20thus%20transformed%20would%20have%20any%20problem%20being%20displayed%20in%20normal%20character%20sets%20in%20email.%20%20It%20looks%20like%20something%20is%20web-ifying%20things%20for%20html-styled%20email%2C%20but%20html%20in%20email%20is%20an%20abomination%20that%20nobody%20should%20accept.%20Is%20that%20what%20github%20sends%3F%20Can%20it%20be%20turned%20off%3F%5Cn%22%2C%20%22created_at%22%3A%20%222014-05-07T22%3A26%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/1242215%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwichmann%22%7D%7D%2C%20%7B%22body%22%3A%20%22foo%2C%20of%20course%20github%20transformed%20it%20back%20for%20the%20display%20on%20githib%2C%20so%20my%20rant%20makes%20no%20sense.%20%20trust%20me%20that%20in%20my%20email%2C%20characters%20mattering%20to%20html%20were%20escaped%20in%20the%20normal%20html%20way.%5Cn%22%2C%20%22created_at%22%3A%20%222014-05-07T22%3A28%3A22Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/1242215%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/mwichmann%22%7D%7D%2C%20%7B%22body%22%3A%20%22Hmm%2C%5Cn%5CnI%20am%20not%20certain%20we%20want%20to%20get%20into%20the%20documentation%20business.%20Documentation%20on%20how%20to%20deal%20with%20SELinux%20is%20already%20available%20%28http%3A//selinuxproject.org/page/Main_Page%29%2C%20as%20is%20documentation%20for%20AppArmor%20%28http%3A//wiki.apparmor.net/index.php/Main_Page%29.%20Many%20ISVs%20choose%20to%20ignore%20this%2C%20I%20doubt%20that%20documentation%20created%20by%20this%20group%20would%20change%20the%20behavior.%5Cn%5CnWhile%20I%20agree%20that%20there%20is%20an%20issue%20for%20ISVs%2C%20I%20fail%20to%20see%20where%20additional%20documentation%20that%20the%20LSB%20working%20group%20would%20create%20and%20then%20maintain%2C%20can%20add%20value.%20Additionally%2C%20any%20documentation%20we%20create%20would%20inevitably%20be%20out%20of%20date%20in%20short%20order%2C%20as%20we%20do%20not%20participate%20in%20the%20upstream%20projects.%5Cn%5CnThis%20smells%20like%20disaster.%5Cn%5Cn-1%5Cn%22%2C%20%22created_at%22%3A%20%222014-05-12T17%3A06%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/1087183%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/rjschwei%22%7D%7D%2C%20%7B%22body%22%3A%20%22Do%20you%20want%20to%20revisit%20or%20clarify%20the%20statements%20from%20the%20Summit%20that%20some%5Cnof%20our%20results%20may%20be%20in%20the%20form%20of%20documentation%3F%5Cn%5CnI%20will%20ping%20Markus%20specifically%20for%20us%20to%20see%20if%20he%20has%20thoughts%20on%20what%20is%5Cnmissing%20based%20on%20his%20comments%20at%20the%20Summit.%5Cn%5CnOn%20Mon%2C%20May%2012%2C%202014%20at%2012%3A06%20PM%2C%20Robert%20Schweikert%20%3C%5Cnnotifications%40github.com%3E%20wrote%3A%5Cn%5Cn%3E%20Hmm%2C%5Cn%3E%20%5Cn%3E%20I%20am%20not%20certain%20we%20want%20to%20get%20into%20the%20documentation%20business.%5Cn%3E%20Documentation%20on%20how%20to%20deal%20with%20SELinux%20is%20already%20available%20%28%5Cn%3E%20http%3A//selinuxproject.org/page/Main_Page%29%2C%20as%20is%20documentation%20for%5Cn%3E%20AppArmor%20%28http%3A//wiki.apparmor.net/index.php/Main_Page%29.%20Many%20ISVs%20choose%5Cn%3E%20to%20ignore%20this%2C%20I%20doubt%20that%20documentation%20created%20by%20this%20group%20would%5Cn%3E%20change%20the%20behavior.%5Cn%3E%20%5Cn%3E%20While%20I%20agree%20that%20there%20is%20an%20issue%20for%20ISVs%2C%20I%20fail%20to%20see%20where%5Cn%3E%20additional%20documentation%20that%20the%20LSB%20working%20group%20would%20create%20and%20then%5Cn%3E%20maintain%2C%20can%20add%20value.%20Additionally%2C%20any%20documentation%20we%20create%20would%5Cn%3E%20inevitably%20be%20out%20of%20date%20in%20short%20order%2C%20as%20we%20do%20not%20participate%20in%20the%5Cn%3E%20upstream%20projects.%5Cn%3E%20%5Cn%3E%20This%20smells%20like%20disaster.%5Cn%3E%20%5Cn%3E%20-1%5Cn%3E%20%5Cn%3E%20%5Cu2014%5Cn%3E%20Reply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHubhttps%3A//github.com/LinuxStandardBase/lsb/pull/15%23issuecomment-42859317%5Cn%3E%20.%5Cn%22%2C%20%22created_at%22%3A%20%222014-05-12T17%3A14%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/7151704%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kayatate%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/LinuxStandardBase/lsb/pull/15#issuecomment-42491417'>General Comment</a></b>
- <a href='https://github.com/mwichmann'><img border=0 src='https://avatars3.githubusercontent.com/u/1242215?v=4' height=16 width=16></a> This is not a comment on the pull request, but a rant about something else: these things arrive by email and end up looking like crap because something is transforming characters.  This issue looked like this when it landed in my mailbox:
- Transformed the proposal from issue #8 [1] to a proposal file
- Moved the Solution Rationale and Distributions Support sections to the Problem Statement, as these &#39;stages&#39; are not yet reached (e.g. Ubuntu and openSUSE do not yet pledge to adhere to this specification, as there is no specification formed, yet)
- Added a State header with state &quot;Problem Statement&quot;
- Corrected the spelling of proper nouns (apparmor -&gt; AppArmor, OpenSUSE -&gt; openSUSE)
&#38; ?? @quot; ??  @gt; ??
Is there ANY way to fix it so the notification emails don't end up cluttered with this garbage? None of the characters thus transformed would have any problem being displayed in normal character sets in email.  It looks like something is web-ifying things for html-styled email, but html in email is an abomination that nobody should accept. Is that what github sends? Can it be turned off?
- <a href='https://github.com/mwichmann'><img border=0 src='https://avatars3.githubusercontent.com/u/1242215?v=4' height=16 width=16></a> foo, of course github transformed it back for the display on githib, so my rant makes no sense.  trust me that in my email, characters mattering to html were escaped in the normal html way.
- <a href='https://github.com/rjschwei'><img border=0 src='https://avatars3.githubusercontent.com/u/1087183?v=4' height=16 width=16></a> Hmm,
I am not certain we want to get into the documentation business. Documentation on how to deal with SELinux is already available (http://selinuxproject.org/page/Main_Page), as is documentation for AppArmor (http://wiki.apparmor.net/index.php/Main_Page). Many ISVs choose to ignore this, I doubt that documentation created by this group would change the behavior.
While I agree that there is an issue for ISVs, I fail to see where additional documentation that the LSB working group would create and then maintain, can add value. Additionally, any documentation we create would inevitably be out of date in short order, as we do not participate in the upstream projects.
This smells like disaster.
-1
- <a href='https://github.com/kayatate'><img border=0 src='https://avatars1.githubusercontent.com/u/7151704?v=4' height=16 width=16></a> Do you want to revisit or clarify the statements from the Summit that some
of our results may be in the form of documentation?
I will ping Markus specifically for us to see if he has thoughts on what is
missing based on his comments at the Summit.
On Mon, May 12, 2014 at 12:06 PM, Robert Schweikert <
notifications@github.com> wrote:
> Hmm,
>
> I am not certain we want to get into the documentation business.
> Documentation on how to deal with SELinux is already available (
> http://selinuxproject.org/page/Main_Page), as is documentation for
> AppArmor (http://wiki.apparmor.net/index.php/Main_Page). Many ISVs choose
> to ignore this, I doubt that documentation created by this group would
> change the behavior.
>
> While I agree that there is an issue for ISVs, I fail to see where
> additional documentation that the LSB working group would create and then
> maintain, can add value. Additionally, any documentation we create would
> inevitably be out of date in short order, as we do not participate in the
> upstream projects.
>
> This smells like disaster.
>
> -1
>
> —
> Reply to this email directly or view it on GitHubhttps://github.com/LinuxStandardBase/lsb/pull/15#issuecomment-42859317
> .


<a href='https://www.codereviewhub.com/LinuxStandardBase/lsb/pull/15?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/LinuxStandardBase/lsb/pull/15?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/LinuxStandardBase/lsb/pull/15'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>