### PR TITLE
Propose to allocate uids from the maximum down

### DIFF
--- a/documents/wip/userNaming.txt
+++ b/documents/wip/userNaming.txt
@@ -159,13 +159,13 @@ penetration of NFSv4 may not be sufficiently high to eliminate this need. In
 an HA fail over environment the potential change in UID of the user on one
 machine and another UID on the fail over machine may not be tolerated. It is
 therefore proposed that the created system users for the cloud frameworks
-be assigned consistent user IDs across distributions start with 99 and working
-down, the order is not of material interest.
+be assigned consistent user IDs across distributions start with 4294967293 and
+working down, the order is not of material interest.
 
-_oneadmin   -> 60001  (system user for openNebula)
-_openstack  -> 60002
-_cloudstack -> 60003
-_eucalyptus -> 60004
+_oneadmin   -> 4294967293  (system user for openNebula)
+_openstack  -> 4294967292
+_cloudstack -> 4294967291
+_eucalyptus -> 4294967290
 
 Using the proposed "_" prefix for the proposed IDs for the cloud frameworks.
 


### PR DESCRIPTION
Suggestion by Jan Engelhardt to avoid clashes with existing deployments:
http://lists.opensuse.org/opensuse-factory/2015-04/msg00336.html
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/LinuxStandardBase/lsb/pull/21%23issuecomment-264487764%22%2C%20%22https%3A//github.com/LinuxStandardBase/lsb/pull/21%23issuecomment-270077122%22%2C%20%22https%3A//github.com/LinuxStandardBase/lsb/pull/21%23issuecomment-270166509%22%2C%20%22https%3A//github.com/LinuxStandardBase/lsb/pull/21%23issuecomment-274474510%22%2C%20%22https%3A//github.com/LinuxStandardBase/lsb/pull/21%23issuecomment-275405519%22%2C%20%22https%3A//github.com/LinuxStandardBase/lsb/pull/21%23issuecomment-275694285%22%2C%20%22https%3A//github.com/LinuxStandardBase/lsb/pull/21%23issuecomment-276028458%22%2C%20%22https%3A//github.com/LinuxStandardBase/lsb/pull/21%23issuecomment-278980383%22%2C%20%22https%3A//github.com/LinuxStandardBase/lsb/pull/21%23issuecomment-279646994%22%2C%20%22https%3A//github.com/LinuxStandardBase/lsb/pull/21%23issuecomment-280674273%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/LinuxStandardBase/lsb/pull/21%23issuecomment-264487764%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22This%20needs%20discussion%20at%20the%20Wednesday%20weekly%20call%2C%20or%20on%20the%20mailing%20list%22%2C%20%22created_at%22%3A%20%222016-12-02T15%3A56%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/151302%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/herrold%22%7D%7D%2C%20%7B%22body%22%3A%20%22so%20was%20this%20discussed%20or%20is%20anything%20needed%20from%20my%20side%3F%22%2C%20%22created_at%22%3A%20%222017-01-03T09%3A35%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/722232%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lnussel%22%7D%7D%2C%20%7B%22body%22%3A%20%22The%20matter%20did%20not%20have%20a%20corresponding%20bug%20in%20our%20Bugzilla%2C%20and%20indeed%2C%20the%20question%20of%20adding%20a%20FHS%20specific%20part%20of%20the%20bugzilla%20had%20been%20pending%20literally%20for%20years%2C%20and%20so%20dropped%20out%20of%20mind.%20%20Also%2C%20with%20the%20Christmas%20/%20New%20Years%20season.%20the%20matter%20has%20not%20yet%20been%20discussed%20in%20the%20weekly%20call.%20%20I%27ll%20try%20to%20remember%20to%20bring%20this%20matter%2C%20ans%20well%20as%20%5Cr%5Cn%20%20%20https%3A//lsbbugs.linuxfoundation.org/show_bug.cgi%3Fid%3D154%5Cr%5Cn%5Cr%5Cnup%20tomorrow%22%2C%20%22created_at%22%3A%20%222017-01-03T17%3A10%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/151302%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/herrold%22%7D%7D%2C%20%7B%22body%22%3A%20%22any%20outcome%3F%22%2C%20%22created_at%22%3A%20%222017-01-23T12%3A19%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/722232%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lnussel%22%7D%7D%2C%20%7B%22body%22%3A%20%22We%20discussed%20during%20yesterday%27s%20call%20--%20bottom%20line%20was%20that%20we%20will%20add%20reviewing%20open%20github%20pull%20requests%20to%20the%20weekly%20Friday%20IRC%20meeting%20--%2010%20am%20US%20ET%2C%20and%20probably%20add%20a%20process%20where%20we%20also%20create%20a%20tracking%20bug%20in%20our%20formal%20bugzilla%2C%20to%20make%20sure%20stakeholders%20who%20follow%20that%20way%20are%20alerted%20to%20go%20%20%27see%20the%20request%27.%20%5Cr%5Cn%5Cr%5CnWe%20have%20not%20yet%20hit%20the%20merits%20of%20the%20proposal%22%2C%20%22created_at%22%3A%20%222017-01-26T14%3A46%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars1.githubusercontent.com/u/151302%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/herrold%22%7D%7D%2C%20%7B%22body%22%3A%20%22A%20few%20thoughts%3A%5Cr%5Cn%5Cr%5Cn%2A%20How%20does%20changing%20the%20allocation%20range%20fix%20the%20problem%20mentioned%20in%20the%20thread%3F%20%20The%20theory%20behind%20Debian%27s%20range%20was%20that%20it%20was%20likely%20safe%20to%20use.%20%20Why%20would%20this%20new%20range%20be%20any%20safer%3F%5Cr%5Cn%2A%20Has%20anyone%20besides%20SUSE%20signed%20on%20to%20the%20idea%3F%20%20I%27m%20nervous%20about%20trying%20to%20mandate%20something%20without%20some%20cross-distro%20buy-in.%22%2C%20%22created_at%22%3A%20%222017-01-27T15%3A37%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/651415%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/licquia%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%27s%20a%20proposal%2C%20nobody%20has%20signed%20up%20for%20anything%20yet.%20The%20explanation%20for%20changing%20the%20proposal%20to%20a%20top%20down%20approach%20is%20here%3A%20https%3A//lists.opensuse.org/opensuse-factory/2015-04/msg00249.html%22%2C%20%22created_at%22%3A%20%222017-01-30T10%3A32%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/722232%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lnussel%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20suppose%20I%27m%20not%20convinced%20by%20the%20argument%20that%20some%20systems%20have%2060%2C000%20or%20more%20users.%20%20If%20you%27re%20running%20a%20system%20like%20that%2C%20changing%20the%20regular%20user%20UID%20range%20to%2C%20say%2C%20131072%20and%20up%20is%20going%20to%20be%20only%20the%20first%2C%20and%20probably%20easiest%2C%20change%20you%27re%20going%20to%20need%20to%20make.%5Cr%5Cn%5Cr%5CnThis%20would%20be%20a%20lot%20less%20controversial%20to%20me%20if%20you%20weren%27t%20asking%20us%20to%20go%20to%20Debian%20and%20tell%20them%20to%20change%20their%20well-established%20policy%20without%20a%20serious%20argument%20that%20their%20policy%20is%20technically%20wrong.%20%20Frankly%2C%20I%20doubt%20that%20would%20hold%20water.%5Cr%5Cn%5Cr%5CnFedora%27s%20policy%20is%20different%2C%20but%20does%20arguably%20have%20a%20problem%20in%20that%20the%20space%20below%20200%20is%20a%20lot%20more%20constrained%2C%20so%20they%20would%20probably%20do%20well%20to%20consider%20switching%20to%20Debian%27s%20policy.%20%20And%2C%20to%20my%20knowledge%2C%20no%20one%20else%20has%20a%20policy%20to%20compete%20with%20Debian%27s.%5Cr%5Cn%5Cr%5CnIf%20you%20think%20there%20is%20a%20good%20technical%20argument%20here%2C%20then%20make%20that%20argument%20with%20Debian%2C%20and%20come%20back%20if%20you%20can%20get%20them%20to%20agree.%20%20Otherwise%2C%20I%20don%27t%20think%20this%20is%20the%20right%20approach.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222017-02-10T15%3A49%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/651415%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/licquia%22%7D%7D%2C%20%7B%22body%22%3A%20%22Do%20you%20know%20who%20to%20contact%20on%20Debian%20side%3F%22%2C%20%22created_at%22%3A%20%222017-02-14T09%3A00%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars2.githubusercontent.com/u/722232%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/lnussel%22%7D%7D%2C%20%7B%22body%22%3A%20%22Probably%20the%20best%20place%20to%20discuss%20such%20things%20for%20Debian%20is%20the%20debian-policy%20mailing%20list%3A%5Cr%5Cn%5Cr%5Cnhttps%3A//lists.debian.org/debian-policy/%5Cr%5Cn%5Cr%5CnIf%20I%20may%20make%20a%20suggestion%3A%20be%20sure%20to%20bring%20some%20folks%20along%20for%20the%20ride%20at%20SUSE%20or%20elsewhere%20that%20want%20this%20to%20happen.%20%20I%20think%20they%20would%20be%20more%20likely%20to%20be%20receptive%20if%20they%20think%20this%20is%20a%20serious%20proposal%20from%20SUSE%2C%20as%20opposed%20to%20some%20guy%27s%20bright%20idea.%22%2C%20%22created_at%22%3A%20%222017-02-17T15%3A06%3A32Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars3.githubusercontent.com/u/651415%3Fv%3D4%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/licquia%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/LinuxStandardBase/lsb/pull/21#issuecomment-264487764'>General Comment</a></b>
- <a href='https://github.com/herrold'><img border=0 src='https://avatars1.githubusercontent.com/u/151302?v=4' height=16 width=16></a> This needs discussion at the Wednesday weekly call, or on the mailing list
- <a href='https://github.com/lnussel'><img border=0 src='https://avatars2.githubusercontent.com/u/722232?v=4' height=16 width=16></a> so was this discussed or is anything needed from my side?
- <a href='https://github.com/herrold'><img border=0 src='https://avatars1.githubusercontent.com/u/151302?v=4' height=16 width=16></a> The matter did not have a corresponding bug in our Bugzilla, and indeed, the question of adding a FHS specific part of the bugzilla had been pending literally for years, and so dropped out of mind.  Also, with the Christmas / New Years season. the matter has not yet been discussed in the weekly call.  I'll try to remember to bring this matter, ans well as
https://lsbbugs.linuxfoundation.org/show_bug.cgi?id=154
up tomorrow
- <a href='https://github.com/lnussel'><img border=0 src='https://avatars2.githubusercontent.com/u/722232?v=4' height=16 width=16></a> any outcome?
- <a href='https://github.com/herrold'><img border=0 src='https://avatars1.githubusercontent.com/u/151302?v=4' height=16 width=16></a> We discussed during yesterday's call -- bottom line was that we will add reviewing open github pull requests to the weekly Friday IRC meeting -- 10 am US ET, and probably add a process where we also create a tracking bug in our formal bugzilla, to make sure stakeholders who follow that way are alerted to go  'see the request'.
We have not yet hit the merits of the proposal
- <a href='https://github.com/licquia'><img border=0 src='https://avatars3.githubusercontent.com/u/651415?v=4' height=16 width=16></a> A few thoughts:
* How does changing the allocation range fix the problem mentioned in the thread?  The theory behind Debian's range was that it was likely safe to use.  Why would this new range be any safer?
* Has anyone besides SUSE signed on to the idea?  I'm nervous about trying to mandate something without some cross-distro buy-in.
- <a href='https://github.com/lnussel'><img border=0 src='https://avatars2.githubusercontent.com/u/722232?v=4' height=16 width=16></a> It's a proposal, nobody has signed up for anything yet. The explanation for changing the proposal to a top down approach is here: https://lists.opensuse.org/opensuse-factory/2015-04/msg00249.html
- <a href='https://github.com/licquia'><img border=0 src='https://avatars3.githubusercontent.com/u/651415?v=4' height=16 width=16></a> I suppose I'm not convinced by the argument that some systems have 60,000 or more users.  If you're running a system like that, changing the regular user UID range to, say, 131072 and up is going to be only the first, and probably easiest, change you're going to need to make.
This would be a lot less controversial to me if you weren't asking us to go to Debian and tell them to change their well-established policy without a serious argument that their policy is technically wrong.  Frankly, I doubt that would hold water.
Fedora's policy is different, but does arguably have a problem in that the space below 200 is a lot more constrained, so they would probably do well to consider switching to Debian's policy.  And, to my knowledge, no one else has a policy to compete with Debian's.
If you think there is a good technical argument here, then make that argument with Debian, and come back if you can get them to agree.  Otherwise, I don't think this is the right approach.
- <a href='https://github.com/lnussel'><img border=0 src='https://avatars2.githubusercontent.com/u/722232?v=4' height=16 width=16></a> Do you know who to contact on Debian side?
- <a href='https://github.com/licquia'><img border=0 src='https://avatars3.githubusercontent.com/u/651415?v=4' height=16 width=16></a> Probably the best place to discuss such things for Debian is the debian-policy mailing list:
https://lists.debian.org/debian-policy/
If I may make a suggestion: be sure to bring some folks along for the ride at SUSE or elsewhere that want this to happen.  I think they would be more likely to be receptive if they think this is a serious proposal from SUSE, as opposed to some guy's bright idea.


<a href='https://www.codereviewhub.com/LinuxStandardBase/lsb/pull/21?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/LinuxStandardBase/lsb/pull/21?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/LinuxStandardBase/lsb/pull/21'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>